### PR TITLE
Border and centre color customization

### DIFF
--- a/analog-clock.html
+++ b/analog-clock.html
@@ -123,6 +123,22 @@ A analog clock
        * @default #009688
        */
 		scolor: String,
+    /**
+       * Clock border color
+       *
+       * @attribute bcolor
+       * @type String
+       * @default #3F51B5
+       */
+		bcolor: String,
+    /**
+       * Clock center color
+       *
+       * @attribute ccolor
+       * @type String
+       * @default #3F51B5
+       */
+		ccolor: String,
 	   /** size of clock
        *
        * @attribute size
@@ -147,9 +163,11 @@ A analog clock
 	 attached:function(){
 		this.$.clock.style.width=this.size;
 		this.$.clock.style.height=this.size;
+    this.$.clock.style.borderColor=this.bcolor;
 		this.$.hour.style.background=this.hcolor;
 		this.$.minute.style.background=this.mcolor;
 		this.$.second.style.background=this.scolor;
+    this.$.centre.style.background=this.ccolor;
 	 },
 	 _runningChanged:function(newValue, oldValue){
 		//this.ready();

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,8 +5,19 @@
 </head>
 <body>
 
+  <p>The default analog clock:</p>
   <analog-clock></analog-clock>
   
-  <analog-clock date="October 13, 2014 10:10:00"></flip-clock>
+  <p>An analog clock with a set date:</p>
+  <analog-clock date="October 13, 2014 10:10:00"></analog-clock>
+  
+  <p>An analog clock with custom colors</p>
+  <analog-clock
+    hcolor="black"
+    mcolor="blue"
+    scolor="green"
+    bcolor="red"
+    ccolor="purple"></analog-clock>
+    
 </body>
 </html>


### PR DESCRIPTION
This adds the ability to modify the colors of the centre and the clock border. It uses the same naming structure used so the border is named `bcolor` and centre is named `ccolor`.

I've also updated the demo to reflect these changes and add a short description of the different demoed scenarios.

Let me know if you require any modifications in order to merge.
